### PR TITLE
sounds.py + tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,71 @@
-.DS_Store
-.idea/
-composition/*.pyc
-composition/__pycache__/
-dac0.eps
-*.sco
-*.pyc
-tests/*.sco
-PyComposition.egg-info/
+# Python Cached and Compiled Files
+*.py[cod]
+*$py.class
+**/__pycache__
+*.so
+.Python
+
+# Detritus from various Python build systems
 build/
+develop-eggs/
 dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+*.manifest
+*.spec
+pip-log.txt
+pip-delete-this-directory.txt
+.pybuilder/
+target/
+__pypackages__/
+
+# Detritus from various Python testing systems
+cover/
+*.cover
+*.py,cover
+htmlcov/
+.hypothesis/
+.nox/
+.tox/
+.cache
+coverage.xml
+.coverage
+.coverage.*
+nosetests.xml
+.pytest_cache/
+
+# Detritus from various virtualenv systems
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Dev Environment Issues
+# Dev - MacOS X
+.DS_Store
+
+# Developer Editor Detritus
+.idea/
+*.swp
+
+# Dev - TotalRecovery Application
+*.sco
+
+# Dev - reference image that doesn't belong in git
+dac0.eps
+

--- a/tests/test_sounds.py
+++ b/tests/test_sounds.py
@@ -1,0 +1,65 @@
+from __future__ import print_function
+import unittest
+from context import thuja
+import thuja.utils as utils
+from thuja import sounds
+
+
+class TestUtils(unittest.TestCase):
+    semitones = [
+        # (frequency, midi, pitch1, pitch2, octave),
+        (    0.00,   0, 'c',  'C',  -1),
+        (    8.66,   1, 'cs', 'C#', -1),
+        (    9.18,   2, 'd',  'D',  -1),
+        (   10.30,   4, 'e',  'E',  -1),
+        (   10.91,   5, 'f',  'F',  -1),
+        (   12.98,   8, 'gs', 'G#', -1),
+        (   20.60,  16, 'e',  'E',   0),
+        (   32.70,  24, 'c',  'C',   1),
+        (   34.65,  25, 'cs', 'C#',  1),
+        (   51.91,  32, 'gs', 'G#',  1),
+        (   73.42,  38, 'd',  'D',   2),
+        (  110.00,  45, 'a',  'A',   2),
+        (  261.63,  60, 'c',  'C',   4),
+        (  329.63,  64, 'e',  'E',   4),
+        ( 1760.00,  93, 'a',  'A',   6),
+        ( 2793.83, 101, 'f',  'F',   7),
+        (13289.75, 128, 'gs', 'G#',  9),
+        ]
+
+    def test_midi_to_pitch(self):
+        for freq, midi, _, pitch, octave in self.semitones:
+            midi = sounds.MidiNote(midi)
+
+            self.assertTrue(pitch == midi.pitch)
+
+            pc = f"{pitch}{octave}"
+            self.assertTrue(pc == midi.to_pitch_class())
+
+    def test_freq_to_midi(self):
+        for freq, midi, _, pitch, octave in self.semitones:
+            calc_midi = sounds.MidiNote.from_frequency(freq).note
+            self.assertTrue(midi == calc_midi)
+
+    def test_midi_to_freq(self):
+        for freq, midi, _, pitch, octave in self.semitones:
+            midi = sounds.MidiNote(midi)
+            calc_freq = round(midi.frequency, 2)
+            self.assertTrue(freq == calc_freq)
+
+    def test_freq_to_pc(self):
+        for freq, midi, _, pitch, octave in self.semitones:
+            pitch_w_octave = f"{pitch}{octave}"
+            pc = sounds.PitchClass.from_frequency(freq)
+            self.assertTrue(pitch_w_octave == str(pc))
+            self.assertTrue(pitch == pc.pitch)
+
+    def test_pc_to_freq(self):
+        for freq, midi, _, pitch, octave in self.semitones:
+            pitch_w_octave = f"{pitch}{octave}"
+            pc = sounds.PitchClass(pitch_w_octave)
+            calc_freq = round(pc.frequency, 2)
+            self.assertTrue(freq == calc_freq)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,6 +11,27 @@ import numpy as np
 
 
 class TestUtils(unittest.TestCase):
+    semitones = [
+        # (frequency, midi, pitch, octave),
+        (    0.00,   0, 'c',  -1),
+        (    8.66,   1, 'cs', -1),
+        (    9.18,   2, 'd',  -1),
+        (   10.30,   4, 'e',  -1),
+        (   10.91,   5, 'f',  -1),
+        (   12.98,   8, 'gs', -1),
+        (   20.60,  16, 'e',   0),
+        (   32.70,  24, 'c',   1),
+        (   34.65,  25, 'cs',  1),
+        (   51.91,  32, 'gs',  1),
+        (   73.42,  38, 'd',   2),
+        (  110.00,  45, 'a',   2),
+        (  261.63,  60, 'c',   4),
+        (  329.63,  64, 'e',   4),
+        ( 1760.00,  93, 'a',   6),
+        ( 2793.83, 101, 'f',   7),
+        (13289.75, 128, 'gs',  9),
+        ]
+
     def test_rhythms(self):
         self.assertTrue(utils.add_rhythm('w', 's') == 'w+s')
         self.assertTrue(utils.add_rhythm('h', 's') == 'h+s')
@@ -38,37 +59,40 @@ class TestUtils(unittest.TestCase):
         self.assertTrue(utils.val_to_rhythm_string(.75) == 'e.')
 
     def test_midinote_to_pc(self):
-        self.assertTrue(utils.midi_note_to_pc(25) == 'cs1')
-        self.assertTrue(utils.midi_note_to_pc(25, False) == 'cs')
-        self.assertTrue(utils.midi_note_to_pc(24) == 'c1')
-        self.assertTrue(utils.midi_note_to_pc(60, False) == 'c')
-        self.assertTrue(utils.midi_note_to_pc(60) == 'c4')
+        for freq, midi, pitch, octave in self.semitones:
+            pitch_w_octave = f"{pitch}{octave}"
+            calc_pitch_w_octave = utils.midi_note_to_pc(midi)
+            self.assertTrue(pitch_w_octave == calc_pitch_w_octave)
+
+            calc_pitch = utils.midi_note_to_pc(midi, False)
+            self.assertTrue(pitch == calc_pitch)
 
     def test_freq_to_midinote(self):
-        self.assertTrue(utils.freq_to_midi_note(73.4161919794) == 38)
-        self.assertTrue(utils.freq_to_midi_note(8.1757989156) == 0)
-        self.assertTrue(utils.freq_to_midi_note(8.6619572180) == 1)
-        self.assertTrue(utils.freq_to_midi_note(10.9133822323) == 5)
-        self.assertTrue(utils.freq_to_midi_note(2793.8258514640) == 101)
-        self.assertTrue(utils.freq_to_midi_note(8.66) == 1)
-        self.assertTrue(utils.freq_to_midi_note(110) == 45)
+        for freq, midi, pitch, octave in self.semitones:
+            calc_midi = utils.freq_to_midi_note(freq)
+            self.assertTrue(midi == calc_midi)
 
     def test_midinote_to_freq(self):
-        self.assertTrue(round(utils.midinote_to_freq(38), 2) == 73.42)
-        # self.assertTrue(round(utils.midinote_to_freq(0), 2) == 8.18)
-        self.assertTrue(round(utils.midinote_to_freq(1), 2) == 8.66)
-        self.assertTrue(round(utils.midinote_to_freq(5), 2) == 10.91)
-        self.assertTrue(round(utils.midinote_to_freq(101), 2) == 2793.83)
-        self.assertTrue(round(utils.midinote_to_freq(45), 2) == 110)
+        for freq, midi, pitch, octave in self.semitones:
+            calc_freq = round(utils.midinote_to_freq(midi), 2)
+            self.assertTrue(calc_freq == freq)
 
     def test_freq_to_pc(self):
-        self.assertTrue(utils.freq_to_pc(8.66, False) == 'cs')
-        self.assertTrue(utils.freq_to_pc(440, True) == 'a4')
+        for freq, midi, pitch, octave in self.semitones:
+            pitch_w_octave = f"{pitch}{octave}"
+            calc_pitch_w_octave = utils.freq_to_pc(freq, True)
+            self.assertTrue(pitch_w_octave == calc_pitch_w_octave)
+
+            calc_pitch = utils.freq_to_pc(freq, False)
+            self.assertTrue(pitch == calc_pitch)
 
     def test_pc_to_freq(self):
-        self.assertTrue(round(utils.pc_to_freq('a4', 4)['value'], 2) == 440.0)
-        self.assertTrue(round(utils.pc_to_freq('a4', 1)['value'], 2) == 440.0)
-        self.assertTrue(round(utils.pc_to_freq('a6', 1)['value'], 2) == 1760.0)
+        for freq, midi, pitch, octave in self.semitones:
+            pitch_w_octave = f"{pitch}{octave}"
+            for default in (octave, octave+1):  # test with wrong default octave
+                calc = utils.pc_to_freq(pitch_w_octave, default)
+                calc_freq = round(calc['value'], 2)
+                self.assertTrue(freq == calc_freq)
 
 if __name__ == '__main__':
     unittest.main()

--- a/thuja/sounds.py
+++ b/thuja/sounds.py
@@ -148,7 +148,7 @@ class PitchClass:
     @staticmethod
     def from_frequency(frequency:float):
         """Converts a frequency in Hertz to a pitch class."""
-        return MidiNote.from_frequency(frequency).pitch_class
+        return PitchClass(MidiNote.from_frequency(frequency).to_pitch_class())
 
     @staticmethod
     def from_midi_note(note:int):
@@ -158,7 +158,7 @@ class PitchClass:
         pitch class spec - [note name][s|f|n][octave]
         examples: b4, c#5, a♭8, a𝄫3
         """
-        return MidiNote(note).pitch_class
+        return PitchClass(MidiNote(note).to_pitch_class())
 
     def to_midi_note(self):
         """
@@ -178,7 +178,7 @@ class PitchClass:
     # properties
     @property
     def frequency(self) -> float:
-        return self.midi.frequency
+        return MidiNote(self.to_midi_note()).frequency
 
     @property
     def octave(self) -> int:

--- a/thuja/sounds.py
+++ b/thuja/sounds.py
@@ -1,0 +1,228 @@
+import math
+
+from thuja.utils import cycle, round_half_down
+
+"""
+Individual tones may be represented as a midi note (MidiNote), a pitch class (PitchClass), or a
+frequency (float).
+"""
+
+SCALE = 12
+SEMITONES = "C_D_EF_G_A_B"  # black piano keys (sharps/flats) are underscores
+
+
+class MidiNote:
+    """
+    Midi notes count 12 notes between each doubling of Hertz, at a baseline of midi 69 equalling
+    frequency 440.0 Hertz (and thus, for example, 880.0 Hertz is equivalent to midi 81).
+
+    This program only handles frequencies down to around 8.42 -- all frequencies below that are
+    midi 0.
+
+    There is no upper limit given here, although midi 135 is the maximum frequency human ears can
+    detect.
+
+    A MidiNote acts like an integer for certain operations, allowing you to do basic math with it.
+    For example:
+
+        >>> from thuja import sounds
+        >>> note = sounds.MidiNote(84)
+        >>> note.PitchClass()
+        PitchClass('C6')
+        >>> (note + 2).PitchClass()
+        PitchClass('D6')
+        >>> (note / 2).PitchClass()
+        PitchClass('F#2')
+    """
+
+    def __init__(self, note:int):
+        self.note = note
+
+    def __repr__(self):
+        return f"MidiNote({self.note})"
+
+    def __int__(self):
+        return self.note
+
+    # alternative creation methods
+    @staticmethod
+    def from_frequency(frequency:float):
+        """Converts a frequency in Hertz to a midi note."""
+        if frequency == 0:  # silence
+            return MidiNote(0)
+
+        unrounded = MidiNote.offset + math.log2(frequency / MidiNote.hertz) * SCALE
+
+        # return a minimum of 0, and always round 0.5 down:
+        return MidiNote(max(0, round_half_down(unrounded)))
+
+    @staticmethod
+    def from_pitch_class(pitch_class:str):
+        """
+        Converts a pitch class notation to a midi note.
+
+        converts pitch class name to midi note
+        pitch class spec - [note name][s|f|n][octave]
+        examples: b4, cs5, af8, an3
+        """
+        return PitchClass(str(pitch_class)).midi
+
+    def to_pitch_class(self):
+        """Returns the pitch class of the midi note as a string."""
+        return f"{self.pitch}{self.octave}"
+
+    # basic properties
+    hertz:float = 440.0
+    offset:int = 69
+
+    @property
+    def note(self):
+        return self._note
+
+    @note.setter
+    def note(self, value:int):
+        self._note = max(0, int(value))
+
+    @property
+    def frequency(self) -> float:
+        """Returns the frequency of the note in Hertz."""
+        if self.note == 0:
+            return 0.0
+
+        power = (self.note - self.offset) / SCALE
+        return self.hertz * 2**power
+
+    @property
+    def octave(self) -> int:
+        return (self.note // SCALE) - 1
+
+    @property
+    def pitch(self) -> str:
+        return semitone_code(self.note)
+
+    # magic methods
+
+    def __add__(self, value:int):
+        return MidiNote(self.note + int(value))
+
+    def __iadd__(self, value:int):
+        self._note = self._note + int(value)
+
+    def __sub__(self, value:int):
+        return MidiNote(self.note - int(value))
+
+    def __isub__(self, value:int):
+        self._note = self._note - int(value)
+
+    def __mul__(self, value:int):
+        return MidiNote(self.note * int(value))
+
+    def __imul__(self, value:int):
+        self._note = self._note * int(value)
+
+    def __truediv__(self, value:int):
+        return MidiNote(self.note // int(value))
+
+    def __itruediv__(self, value:int):
+        self._note = self.note // int(value)
+
+    def __floordiv__(self, value:int):
+        return self / value  # same as truediv
+
+    def __ifloordiv__(self, value:int):
+        self /= value  # same as itruediv
+
+
+class PitchClass:
+    """"""
+    def __init__(self, pc:str):
+        self._pc = str(pc)
+
+    def __repr__(self):
+        return f"PitchClass('{self.pitch}{self.octave}')"
+
+    def __str__(self):
+        return f"{self.pitch}{self.octave}"
+
+    # alternative creation methods
+    @staticmethod
+    def from_frequency(frequency:float):
+        """Converts a frequency in Hertz to a pitch class."""
+        return MidiNote.from_frequency(frequency).pitch_class
+
+    @staticmethod
+    def from_midi_note(note:int):
+        """
+        Converts a midi note to a pitch class notation.
+
+        pitch class spec - [note name][s|f|n][octave]
+        examples: b4, c#5, a♭8, a𝄫3
+        """
+        return MidiNote(note).pitch_class
+
+    def to_midi_note(self):
+        """
+        Converts a pitch class notation to a midi note integer.
+
+        converts pitch class name to midi note
+        pitch class spec - [note name][s|f|n][octave]
+        examples: b4, cs5, af8, an3
+        """
+        if self.pitch == 'r':
+            return MidiNote(0)
+
+        note = semitone_int(self._pc)
+
+        return (1 + self.octave) * 12 + note
+
+    # properties
+    @property
+    def frequency(self) -> float:
+        return self.midi.frequency
+
+    @property
+    def octave(self) -> int:
+        octave = 5  # default
+        if len(self._pc) > len(self.pitch):
+            octave = int(self._pc[len(self.pitch):])
+        return octave
+
+    @property
+    def pitch(self) -> str:
+        return semitone_code(semitone_int(self._pc))
+
+
+def accidental_modifier(mark:str):
+    "Accepts a mark (# or S, ♭ or F, 𝄫 or D) and returns the semitone interval (+1, -1, -2)."
+    mark = str(mark)[0]
+    accidentals = {
+        '#':  1,    'S':  1,  # sharp
+        '♭': -1,    'F': -1,  # flat
+        '𝄫': -2,    'D': -2,  # double flat
+        }
+    if mark in accidentals:
+        return accidentals[mark]
+    return 0
+
+
+def semitone_int(code:str) -> int:
+    "Accepts a code and returns the semitone: C# -> 1."
+    letter = code[0].upper()
+    index = SEMITONES.index(letter)
+
+    if len(code) > 1:
+        index += accidental_modifier(code[1].upper())
+
+    return cycle(index)
+
+
+def semitone_code(index:int):
+    "Accepts an integer and returns the semitone: 1 -> C#."
+    index = cycle(index)
+
+    code = SEMITONES[index]
+    if code == '_':
+        index = cycle(index - 1)
+        code = SEMITONES[index] + '#'
+
+    return code

--- a/thuja/utils.py
+++ b/thuja/utils.py
@@ -62,7 +62,9 @@ def pc_to_freq(pc, default_octave):
     midinote = int(pc_spec.index(pc[0]))
 
     if pc[len(pc)-1].isdigit():
-            octave = int(pc[len(pc)-1])
+        octave = int(pc[len(pc)-1])
+        if len(pc)>2 and pc[-2] == '-':
+            octave = 0 - octave
 
     midinote += 12*(octave+1)
 

--- a/thuja/utils.py
+++ b/thuja/utils.py
@@ -1,6 +1,27 @@
 import math
 from collections import OrderedDict
 
+
+# Some Maths Utilities
+def cycle(index:int, scale:int=12):
+    """
+    Conforms an integer to a particular scale (usually the 12-point midi scale), wrapping the
+    number back around when it gets too high or too low.
+
+    For example, on a scale of 0-11 (the 12-point scale), a -1 becomes an 11, a -2 becomes a 10,
+    and so on; and a 12 becomes 0, 13 becomes 1, and so on.
+    """
+    while index < 0:
+        index += scale  # wrap negative numbers
+    return index % scale  # wrap high numbers
+
+
+def round_half_down(value:float) -> int:
+    """Rounds a floating-point number, with an 0.5 always rounding down."""
+    return math.ceil(value - 0.5)
+
+
+# Conversion Utilities
 pc_spec = list("cxdxefxgxaxb")
 
 


### PR DESCRIPTION
This was an experiment, but one I think might be useful. It includes the other two pull requests, and assumes they're accepted first. If they're not accepted, I can cherry-pick a new version of this pretty easily.

I wrote some new code based on the sounds-only subset of thuja.utils, called thuja.sounds.

* A MidiNote class.
* A PitchClass class.
* A few math utilities useful for those.

I also did a few cleanup bits:

* added tests for thuja.sounds in tests.test_sounds.
* fixed thuja.utils to pass the new tests.

Assuming this is accepted, the next step would be to replace the utils converting between pitch, frequency, and midi with the thuja.sound usages.