### PR TITLE
Fix mutable default args in NoteGenerator.__init__

### DIFF
--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -326,6 +326,16 @@ class TestGenerators(unittest.TestCase):
 
         pass
 
+    def test_mutable_default_args(self):
+        # Regression test for issue #13: post_processes=[] and gen_lines=[] as default
+        # args caused all instances to share the same list object.
+        g1 = NoteGenerator()
+        g2 = NoteGenerator()
+        g1.post_processes.append(lambda note: note)
+        g1.gen_lines.append('f 1 0 16384 10 1')
+        self.assertEqual(len(g2.post_processes), 0)
+        self.assertEqual(len(g2.gen_lines), 0)
+
     def test_line_pitches_with_string(self):
         # Regression test for issue #12: Line.pitches() with a string arg was raising
         # NameError because it referenced Notetypes() instead of notetypes.

--- a/thuja/notegenerator.py
+++ b/thuja/notegenerator.py
@@ -21,9 +21,9 @@ class NoteGenerator:
                  start_time=0.0,
                  streams=None,
                  pfields=None,
-                 post_processes=[],
+                 post_processes=None,
                  init_context=None,
-                 gen_lines=[]):
+                 gen_lines=None):
         """
         Initializes a Generator object.ˆ
 
@@ -53,7 +53,7 @@ class NoteGenerator:
         #   generator_dur can be used to set a relative time limit after that offset occurs in generate_notes
         self.generator_dur = 0
 
-        self.gen_lines = gen_lines
+        self.gen_lines = gen_lines if gen_lines is not None else []
         self.note_count = 0
         self.notes = []
         self.end_lines = []
@@ -72,7 +72,7 @@ class NoteGenerator:
             self.context = {}
 
         # an array of callables, called in sequence after each note is initialized.
-        self.post_processes = post_processes
+        self.post_processes = post_processes if post_processes is not None else []
 
         self.generators = []
 


### PR DESCRIPTION
`post_processes=[]` and `gen_lines=[]` as default arguments caused all `NoteGenerator` instances that didn't explicitly pass these args to share the same list object. Appending to one would silently affect others.

Changed both defaults to `None`, initialized to `[]` in the body.

Adds a regression test confirming two independently-created instances have independent lists.

Closes #13