### PR TITLE
Fix NoteGenerator.with_streams()

### DIFF
--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -326,6 +326,24 @@ class TestGenerators(unittest.TestCase):
 
         pass
 
+    def test_with_streams_ordered_dict(self):
+        # Regression test for issue #15: with_streams() with an OrderedDict was
+        # being overwritten by the else branch, and didn't return self.
+        od = OrderedDict([(keys.instrument, Itemstream([1]))])
+        g = NoteGenerator().with_streams(od)
+        self.assertIs(g.streams, od)
+
+    def test_with_streams_plain_dict(self):
+        d = [(keys.instrument, Itemstream([1]))]
+        g = NoteGenerator().with_streams(d)
+        self.assertIsInstance(g.streams, OrderedDict)
+        self.assertIn(keys.instrument, g.streams)
+
+    def test_with_streams_returns_self(self):
+        g = NoteGenerator()
+        result = g.with_streams(OrderedDict())
+        self.assertIs(result, g)
+
     def test_mutable_default_args(self):
         # Regression test for issue #13: post_processes=[] and gen_lines=[] as default
         # args caused all instances to share the same list object.

--- a/thuja/notegenerator.py
+++ b/thuja/notegenerator.py
@@ -79,10 +79,9 @@ class NoteGenerator:
     def with_streams(self, streams):
         if isinstance(streams, OrderedDict):
             self.streams = streams
-        if streams is None:
-            pass
-        else:
+        elif streams is not None:
             self.streams = OrderedDict(streams)
+        return self
 
     def with_pfields(self, pfields):
         self.pfields = pfields


### PR DESCRIPTION
Two bugs in `with_streams()`:

1. The second `if` should have been `elif` — as written, the `else` branch always ran, overwriting an already-correct `OrderedDict` assignment with `OrderedDict(streams)` (worked by accident but was wrong logic).
2. The method didn't `return self`, so it couldn't be chained like other fluent methods. Compare: `with_pfields()` correctly returns `self`.

Adds three regression tests: OrderedDict path, plain dict/list path, and chaining (`returns self`).

Closes #15