### PR TITLE
Rename NoteGenerator.tempo() to get_tempo()

### DIFF
--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -326,6 +326,19 @@ class TestGenerators(unittest.TestCase):
 
         pass
 
+    def test_get_tempo_on_note_generator(self):
+        # Regression test for issue #14: NoteGenerator.tempo() renamed to get_tempo()
+        # to avoid collision with Line.tempo(x) fluent setter.
+        g = NoteGenerator(streams=OrderedDict([
+            (keys.rhythm, Itemstream(['q'], notetype=notetypes.rhythm))
+        ]))
+        g.streams[keys.rhythm].tempo = 90
+        self.assertEqual(g.get_tempo(), 90)
+
+    def test_line_tempo_setter_still_works(self):
+        line = Line().with_rhythm('q').with_tempo(90)
+        self.assertEqual(line.streams[keys.rhythm].tempo, 90)
+
     def test_with_streams_ordered_dict(self):
         # Regression test for issue #15: with_streams() with an OrderedDict was
         # being overwritten by the else branch, and didn't return self.

--- a/thuja/notegenerator.py
+++ b/thuja/notegenerator.py
@@ -358,7 +358,7 @@ class NoteGenerator:
         for x in range(len(self.notes)):
             sock.sendto(("&" + self.notes[x]).encode(), (UDP_IP, UDP_PORT))
 
-    def tempo(self):
+    def get_tempo(self):
         return self.streams[keys.rhythm].tempo
 
     def set_streams_to_seed(self, seed):


### PR DESCRIPTION
`NoteGenerator.tempo()` was a no-arg getter returning `self.streams[keys.rhythm].tempo`. `Line.tempo(x)` is a fluent setter that takes a value and returns `self`. Same name, opposite semantics — the base class getter was silently shadowed and unreachable on all `Line` instances.

**Fix**: rename `NoteGenerator.tempo()` → `get_tempo()`.

**Also updates two live call sites in csound-pieces** that were correctly using the getter on `NoteGenerator` instances:
- `thuja-ep/chapel_october_2022/chapel_october_1.py:157`
- `thuja-ep/books-style/index_study_1_respiration.py:149`

Adds regression tests for both `get_tempo()` and `Line.tempo()` setter.

Closes #14