### PR TITLE
Move g() and randomize() from Line up to NoteGenerator

### DIFF
--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -326,6 +326,27 @@ class TestGenerators(unittest.TestCase):
 
         pass
 
+    def test_g_on_note_generator(self):
+        # g() should be available on NoteGenerator, not just Line
+        g = NoteGenerator(streams=OrderedDict([
+            (keys.instrument, Itemstream([1])),
+            (keys.duration, Itemstream([1])),
+            (keys.rhythm, Itemstream(['q'], notetype=notetypes.rhythm)),
+        ]), note_limit=4)
+        result = g.g()
+        self.assertIs(result, g)
+        self.assertEqual(len(g.notes), 4)
+
+    def test_randomize_on_note_generator(self):
+        # randomize() should be available on NoteGenerator, not just Line
+        g = NoteGenerator(streams=OrderedDict([
+            (keys.instrument, Itemstream([1])),
+            (keys.duration, Itemstream([1])),
+            (keys.rhythm, Itemstream(['q'], notetype=notetypes.rhythm)),
+        ]), note_limit=4)
+        result = g.randomize()
+        self.assertIs(result, g)
+
     def test_get_tempo_on_note_generator(self):
         # Regression test for issue #14: NoteGenerator.tempo() renamed to get_tempo()
         # to avoid collision with Line.tempo(x) fluent setter.

--- a/thuja/notegenerator.py
+++ b/thuja/notegenerator.py
@@ -361,6 +361,15 @@ class NoteGenerator:
     def get_tempo(self):
         return self.streams[keys.rhythm].tempo
 
+    def randomize(self):
+        seed = random.Random().randint(0, sys.maxsize)
+        self.set_streams_to_seed(seed)
+        return self
+
+    def g(self):
+        self.generate_notes()
+        return self
+
     def set_streams_to_seed(self, seed):
         for s in self.streams.values():
             if isinstance(s, Itemstream):
@@ -506,11 +515,6 @@ class Line(NoteGenerator):
         self.set_stream(StreamKey().percent, v)
         return self
 
-    def randomize(self):
-        seed = random.Random().randint(0, sys.maxsize)
-        self.set_streams_to_seed(seed)
-        return self
-
     def with_index(self, v):
         return self.index(v)
 
@@ -525,10 +529,6 @@ class Line(NoteGenerator):
         self.set_stream('fade_in', .0001)
         self.set_stream('fade_out', .01)
         self.pfields += [keys.index, 'orig_rhythm', 'inst_file', 'fade_in', 'fade_out']
-        return self
-
-    def g(self):
-        self.generate_notes()
         return self
 
 


### PR DESCRIPTION
Both methods have no `Line`-specific logic:

- `randomize()` just calls `set_streams_to_seed()` which already lives in `NoteGenerator`
- `g()` is just `generate_notes()` returning `self`

Moving them to the base class makes them available to all generator users, not just `Line`.

Non-breaking — `Line` inherits both transparently.

Closes #16