### PR TITLE
Move set_stream() type coercion from Line up to NoteGenerator

### DIFF
--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -326,6 +326,30 @@ class TestGenerators(unittest.TestCase):
 
         pass
 
+    def test_set_stream_itemstream(self):
+        # set_stream() should be available on NoteGenerator, not just Line
+        g = NoteGenerator(streams=OrderedDict([(keys.instrument, Itemstream([1]))]))
+        stream = Itemstream([2])
+        g.set_stream(keys.instrument, stream)
+        self.assertIs(g.streams[keys.instrument], stream)
+
+    def test_set_stream_string(self):
+        g = NoteGenerator(streams=OrderedDict([(keys.instrument, Itemstream([1]))]))
+        g.set_stream(keys.instrument, '1 2 3')
+        self.assertIsInstance(g.streams[keys.instrument], Itemstream)
+        self.assertEqual(g.streams[keys.instrument].values, ['1', '2', '3'])
+
+    def test_set_stream_list(self):
+        g = NoteGenerator(streams=OrderedDict([(keys.instrument, Itemstream([1]))]))
+        g.set_stream(keys.instrument, [1, 2, 3])
+        self.assertIsInstance(g.streams[keys.instrument], Itemstream)
+
+    def test_set_stream_callable(self):
+        g = NoteGenerator(streams=OrderedDict([(keys.duration, Itemstream([1]))]))
+        fn = lambda note: note.rhythm * 2
+        g.set_stream(keys.duration, fn)
+        self.assertTrue(callable(g.streams[keys.duration]))
+
     def test_g_on_note_generator(self):
         # g() should be available on NoteGenerator, not just Line
         g = NoteGenerator(streams=OrderedDict([

--- a/thuja/notegenerator.py
+++ b/thuja/notegenerator.py
@@ -118,6 +118,19 @@ class NoteGenerator:
         self.streams[key] = stream
         return self
 
+    def set_stream(self, k, v):
+        if isinstance(v, Itemstream):
+            self.streams[k] = v
+        elif isinstance(v, str):
+            self.streams[k] = Itemstream(v.split())
+        elif isinstance(v, list):
+            self.streams[k] = Itemstream(v)
+        elif callable(v):
+            self.streams[k] = v
+        else:
+            # assume this is a single item and pass value through to ItemStream
+            self.streams[k] = Itemstream(v)
+
     def generate_score(self, filename=None):
         self.note_count = 0
         self.notes = []
@@ -413,20 +426,6 @@ class Line(NoteGenerator):
                                'f 3 0 256 7 1 128 1 0 -1 128 -1\n']
         self.note_limit = 0
 
-
-    def set_stream(self, k, v):
-        if isinstance(v, Itemstream):
-            self.streams[k] = v
-        elif isinstance(v, str):
-            self.streams[k] = Itemstream(v.split())
-        elif isinstance(v, list):
-            self.streams[k] = Itemstream(v)
-        elif callable(v):
-            self.streams[k] = v
-
-        else:
-            # assume this is an single item string and pass value through to ItemStream
-            self.streams[k] = Itemstream(v)
 
     def with_rhythm(self, v):
         return self.rhythms(v)


### PR DESCRIPTION
`set_stream()` wraps strings, lists, and callables into `Itemstream` objects. This logic has no `Line`-specific dependency — it's purely about ergonomic stream assignment. Moving it to `NoteGenerator` gives base class users the same convenience without needing to construct `Itemstream` objects manually every time.

`Line`'s fluent builder methods (`rhythms()`, `pitches()`, etc.) continue to call `self.set_stream()` as before — no behavior change.

Adds four regression tests covering all coercion paths: `Itemstream`, `str`, `list`, and `callable`.

Closes #17