### PR TITLE
Extract setup_index_params_with_file() from Line into utils

### DIFF
--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -326,6 +326,19 @@ class TestGenerators(unittest.TestCase):
 
         pass
 
+    def test_setup_index_params(self):
+        # Regression test for issue #18: setup_index_params_with_file() extracted
+        # from Line to utils.setup_index_params(generator, filename).
+        line = Line().with_rhythm('q').with_pitches('c4')
+        utils.setup_index_params(line, '/path/to/file.wav')
+        self.assertIn('orig_rhythm', line.streams)
+        self.assertIn('inst_file', line.streams)
+        self.assertIn('fade_in', line.streams)
+        self.assertIn('fade_out', line.streams)
+        self.assertIn(keys.index, line.pfields)
+        self.assertIn('orig_rhythm', line.pfields)
+        self.assertIn('inst_file', line.pfields)
+
     def test_set_stream_itemstream(self):
         # set_stream() should be available on NoteGenerator, not just Line
         g = NoteGenerator(streams=OrderedDict([(keys.instrument, Itemstream([1]))]))

--- a/thuja/notegenerator.py
+++ b/thuja/notegenerator.py
@@ -522,13 +522,6 @@ class Line(NoteGenerator):
         return self
 
 
-    def setup_index_params_with_file(self, filename):
-        self.set_stream('orig_rhythm', .01)
-        self.set_stream('inst_file', ['\"' + filename + '\"'])
-        self.set_stream('fade_in', .0001)
-        self.set_stream('fade_out', .01)
-        self.pfields += [keys.index, 'orig_rhythm', 'inst_file', 'fade_in', 'fade_out']
-        return self
 
 
 class NoteGeneratorThread(threading.Thread):

--- a/thuja/utils.py
+++ b/thuja/utils.py
@@ -264,3 +264,18 @@ def dur_of_quarter(tempo):
 def quarter_duration_to_tempo(dur):
     return 60 * (1/dur)
 
+def setup_index_params(generator, filename):
+    """
+    Configures a generator for index-based sample playback by adding the
+    standard pfields used with index-style Csound instruments: index,
+    orig_rhythm, inst_file, fade_in, and fade_out.
+    """
+    from thuja.streamkeys import keys
+    generator.set_stream('orig_rhythm', .01)
+    generator.set_stream('inst_file', ['"' + filename + '"'])
+    generator.set_stream('fade_in', .0001)
+    generator.set_stream('fade_out', .01)
+    for field in [keys.index, 'orig_rhythm', 'inst_file', 'fade_in', 'fade_out']:
+        if field not in generator.pfields:
+            generator.pfields.append(field)
+


### PR DESCRIPTION
`Line.setup_index_params_with_file()` was domain-specific boilerplate for index-based sample playback: hardcoded stream names (`orig_rhythm`, `inst_file`, `fade_in`, `fade_out`), direct `pfields` mutation, and no `Line`-specific logic. It appeared in only 2 files in csound-pieces while 30+ files implement the same pattern manually.

Extracted to `utils.setup_index_params(generator, filename)` — works with any generator type, not just `Line`.

Also updates the one method call site in `csound-pieces/thuja-ep/1min-cs/153.py`.

Closes #18