### PR TITLE
Fix heap/random first-draw bug; add reproducibility tests (#31)

### DIFF
--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -660,93 +660,423 @@ class TestGenerators(unittest.TestCase):
         self.assertEqual(line.streams[keys.frequency].notetype, notetypes.pitch)
 
     # ------------------------------------------------------------------ #
-    # set_streams_to_seed  (#31)
+    # Pitch stream edge cases: rests, octave persistence, chords+rests  (#33)
     # ------------------------------------------------------------------ #
+    # Line pfield positions in the score line (split by whitespace):
+    #   [0] = 'i' + instrument   [3] = amplitude
+    #   [1] = start_time         [4] = frequency
+    #   [2] = duration           [5] = pan  ...
 
-    def test_set_streams_to_seed_two_generators_same_seed_same_output(self):
-        # Two independent generators with identical config and the same seed
-        # passed to set_streams_to_seed() before generate_notes() produce
-        # identical note lists. This is how it's used in csound-pieces to
-        # create deterministic variations:
-        #   gen1.set_streams_to_seed(int(time.time()))
-        #   gen2.set_streams_to_seed(int(time.time()) + 100)
-        def make_gen():
-            g = NoteGenerator(
+    def test_rest_produces_frequency_zero(self):
+        # 'r' in a pitch stream resolves to frequency 0.
+        # The amplitude stream is unaffected — only frequency changes.
+        gen = (Line()
+               .with_rhythm(Itemstream(['q'], notetype=notetypes.rhythm))
+               .with_pitches(Itemstream(['c4', 'r', 'e4'], notetype=notetypes.pitch,
+                                        streammode=streammodes.sequence)))
+        gen.note_limit = 3
+        gen.generate_notes()
+
+        freqs = [float(note.split()[4]) for note in gen.notes]
+        self.assertGreater(freqs[0], 0)   # c4 → non-zero freq
+        self.assertEqual(freqs[1], 0.0)   # 'r' → frequency 0
+        self.assertGreater(freqs[2], 0)   # e4 → non-zero freq
+
+    def test_rest_does_not_zero_amplitude(self):
+        # 'r' only sets frequency to 0 — it does not modify the amplitude stream.
+        # The amplitude value from the amp stream is still emitted for a rest note.
+        gen = (Line()
+               .with_rhythm(Itemstream(['q'], notetype=notetypes.rhythm))
+               .with_pitches(Itemstream(['c4', 'r'], notetype=notetypes.pitch,
+                                        streammode=streammodes.sequence))
+               .with_amps(0.75))
+        gen.note_limit = 2
+        gen.generate_notes()
+
+        amp_on_rest = float(gen.notes[1].split()[3])
+        self.assertAlmostEqual(amp_on_rest, 0.75)
+
+    def test_octave_persistence_bare_note_inherits_previous_octave(self):
+        # When a pitch name has no octave digit, it inherits the octave
+        # from the previous pitch in the stream.
+        # 'c4 d e' → c4, d4, e4 (d and e inherit octave 4 from c4)
+        stream = Itemstream(['c4', 'd', 'e'], notetype=notetypes.pitch,
+                            streammode=streammodes.sequence)
+        c4_freq = stream.get_next_value()
+        d4_freq = stream.get_next_value()
+        e4_freq = stream.get_next_value()
+
+        # Verify that d and e resolved to octave 4 by checking against
+        # streams where the octave is explicitly specified
+        stream_explicit = Itemstream(['c4', 'd4', 'e4'], notetype=notetypes.pitch,
+                                     streammode=streammodes.sequence)
+        self.assertAlmostEqual(c4_freq, stream_explicit.get_next_value())
+        self.assertAlmostEqual(d4_freq, stream_explicit.get_next_value())
+        self.assertAlmostEqual(e4_freq, stream_explicit.get_next_value())
+
+    def test_octave_persistence_updates_when_new_octave_specified(self):
+        # A new octave digit resets the persistent octave for subsequent pitches.
+        # 'c4 d c5 e' → c4, d4, c5, e5
+        stream = Itemstream(['c4', 'd', 'c5', 'e'], notetype=notetypes.pitch,
+                            streammode=streammodes.sequence)
+        freqs = [stream.get_next_value() for _ in range(4)]
+
+        explicit = Itemstream(['c4', 'd4', 'c5', 'e5'], notetype=notetypes.pitch,
+                              streammode=streammodes.sequence)
+        expected = [explicit.get_next_value() for _ in range(4)]
+
+        for f, e in zip(freqs, expected):
+            self.assertAlmostEqual(f, e)
+
+    def test_octave_does_not_persist_across_separate_streams(self):
+        # Octave state is per-stream — a new Itemstream always starts
+        # with octave 0 (no inherited octave from a previous stream).
+        stream1 = Itemstream(['c4'], notetype=notetypes.pitch, streammode=streammodes.sequence)
+        stream2 = Itemstream(['d'], notetype=notetypes.pitch, streammode=streammodes.sequence)
+
+        stream1.get_next_value()   # sets stream1's current_octave to 4
+        d_no_octave = stream2.get_next_value()  # stream2 starts fresh
+
+        stream_explicit = Itemstream(['d4'], notetype=notetypes.pitch, streammode=streammodes.sequence)
+        d4_freq = stream_explicit.get_next_value()
+
+        # 'd' without context should NOT resolve to d4 — it inherits stream2's default octave (0)
+        self.assertNotAlmostEqual(d_no_octave, d4_freq)
+
+    def test_chord_with_rest_in_same_stream(self):
+        # A pitch stream can contain chords (nested lists) and rests side by side.
+        # Chord: 3 simultaneous notes. Rest: 1 note with frequency 0.
+        gen = (Line()
+               .with_rhythm(Itemstream(['q'], notetype=notetypes.rhythm))
+               .with_pitches(Itemstream([['c4', 'e4', 'g4'], 'r', 'd4'],
+                                        notetype=notetypes.pitch,
+                                        streammode=streammodes.sequence)))
+        gen.note_limit = 5   # chord(3) + rest(1) + single(1)
+        gen.generate_notes()
+
+        freqs = [float(note.split()[4]) for note in gen.notes]
+        start_times = [float(note.split()[1]) for note in gen.notes]
+
+        # First 3 notes share the same start time (the chord)
+        self.assertEqual(start_times[0], start_times[1])
+        self.assertEqual(start_times[1], start_times[2])
+        # All chord frequencies are non-zero
+        self.assertTrue(all(f > 0 for f in freqs[:3]))
+
+        # 4th note is the rest: frequency = 0
+        self.assertEqual(freqs[3], 0.0)
+
+        # 5th note is d4: frequency > 0, starts after the rest
+        self.assertGreater(freqs[4], 0)
+        self.assertGreater(start_times[4], start_times[3])
+
+    # Line fluent API: with_instr, with_index, path notetype, pfields  (#34)
+    # ------------------------------------------------------------------ #
+    # Line default pfield order in the score string (split by whitespace):
+    #   [0] = 'i' + instrument    instrument is embedded: 'i1', 'i4', etc.
+    #   [1] = start_time
+    #   [2] = duration
+    #   [3] = amplitude
+    #   [4] = frequency
+    #   [5] = pan
+    #   [6] = distance
+    #   [7] = percent
+
+    def test_lambda_on_pan_produces_constant_return_value(self):
+        # A lambda assigned to pan is called once per note.
+        # The return value appears at position [5] in the score line.
+        gen = (Line()
+               .with_rhythm(Itemstream(['q'], notetype=notetypes.rhythm))
+               .with_pitches('c4')
+               .with_pan(lambda note: 72.0))
+        gen.note_limit = 4
+        gen.generate_notes()
+
+        for note in gen.notes:
+            self.assertAlmostEqual(float(note.split()[5]), 72.0)
+
+    def test_lambda_on_amplitude_produces_constant_return_value(self):
+        # A lambda assigned to amplitude is called once per note.
+        # The return value appears at position [3] in the score line.
+        gen = (Line()
+               .with_rhythm(Itemstream(['q'], notetype=notetypes.rhythm))
+               .with_pitches('c4')
+               .with_amps(lambda note: 0.25))
+        gen.note_limit = 4
+        gen.generate_notes()
+
+        for note in gen.notes:
+            self.assertAlmostEqual(float(note.split()[3]), 0.25)
+
+    def test_lambda_on_percent_produces_constant_return_value(self):
+        # A lambda assigned to percent is called once per note.
+        # The return value appears at position [7] in the score line.
+        gen = (Line()
+               .with_rhythm(Itemstream(['q'], notetype=notetypes.rhythm))
+               .with_pitches('c4')
+               .with_percent(lambda note: 0.99))
+        gen.note_limit = 4
+        gen.generate_notes()
+
+        for note in gen.notes:
+            self.assertAlmostEqual(float(note.split()[7]), 0.99)
+
+    def test_lambda_on_pan_can_read_note_rhythm(self):
+        # Lambdas receive the note object after rhythm is set, so they can
+        # reference note.rhythm to compute a value. This is the pattern used
+        # in csound-pieces for tempo-aware pfield values.
+        # At 120bpm, q = 0.5s.  The lambda returns rhythm * 100 = 50.0.
+        gen = (Line()
+               .with_rhythm(Itemstream(['q'], notetype=notetypes.rhythm))
+               .with_pitches('c4')
+               .with_pan(lambda note: note.rhythm * 100))
+        gen.note_limit = 2
+        gen.generate_notes()
+
+        for note in gen.notes:
+            self.assertAlmostEqual(float(note.split()[5]), 50.0)
+
+    def test_lambda_produces_different_values_per_note(self):
+        # Lambdas are called fresh for each note, so they can vary per note.
+        counter = {'n': 0}
+
+        def incrementing_pan(note):
+            counter['n'] += 10
+            return float(counter['n'])
+
+        gen = (Line()
+               .with_rhythm(Itemstream(['q'], notetype=notetypes.rhythm))
+               .with_pitches('c4')
+               .with_pan(incrementing_pan))
+        gen.note_limit = 3
+        gen.generate_notes()
+
+        pan_values = [float(note.split()[5]) for note in gen.notes]
+        self.assertEqual(pan_values, [10.0, 20.0, 30.0])
+
+    # ------------------------------------------------------------------ #
+    # Line fluent API: with_instr, with_index, path notetype, pfields  (#34)
+    # ------------------------------------------------------------------ #
+    # Line default pfield order in the score string (split by whitespace):
+    #   [0] = 'i' + instrument    instrument is embedded: 'i1', 'i4', etc.
+    #   [1] = start_time
+    #   [2] = duration
+    #   [3] = amplitude
+    #   [4] = frequency
+    #   [5] = pan  ...
+
+    def test_with_instr_sets_instrument_number_in_score(self):
+        # with_instr(n) sets p1 — the Csound instrument number.
+        # In the score string, instrument is embedded in split()[0] as 'i<n>'.
+        gen = (Line()
+               .with_rhythm(Itemstream(['q'], notetype=notetypes.rhythm))
+               .with_pitches('c4')
+               .with_instr(7))
+        gen.note_limit = 1
+        gen.generate_notes()
+
+        instr = int(gen.notes[0].split()[0][1:])   # strip leading 'i'
+        self.assertEqual(instr, 7)
+
+    def test_with_index_value_appears_in_score(self):
+        # with_index(n) adds an index stream, but index must also be in pfields
+        # to appear in the score — this mirrors the real usage pattern where
+        # setup_index_params or manual pfields.append() is required.
+        gen = (Line()
+               .with_rhythm(Itemstream(['q'], notetype=notetypes.rhythm))
+               .with_pitches('c4')
+               .with_index(3.5))
+        gen.pfields.append(keys.index)
+        gen.note_limit = 1
+        gen.generate_notes()
+
+        fields = gen.notes[0].split()
+        index_val = float(fields[len(fields) - 1])   # last column
+        self.assertAlmostEqual(index_val, 3.5)
+
+    def test_path_notetype_returns_quoted_string_unchanged(self):
+        # notetypes.path wraps the string in double-quotes and passes it through
+        # without any pitch or rhythm conversion.
+        stream = Itemstream(['/samples/kick.wav'], notetype=notetypes.path)
+        val = stream.get_next_value()
+        self.assertEqual(val, '"/samples/kick.wav"')
+
+    def test_path_notetype_does_not_convert_to_frequency(self):
+        # A path string would raise an error or produce garbage if treated as pitch.
+        # Confirm notetypes.path leaves the value intact as a string.
+        stream = Itemstream(['/samples/snare.wav'], notetype=notetypes.path)
+        val = stream.get_next_value()
+        self.assertIsInstance(val, str)
+        self.assertIn('/samples/snare.wav', val)
+
+    def test_custom_pfield_appended_to_pfields_appears_in_score(self):
+        # A custom stream added via set_stream() only appears in the score
+        # when its key is also appended to generator.pfields.
+        gen = (Line()
+               .with_rhythm(Itemstream(['q'], notetype=notetypes.rhythm))
+               .with_pitches('c4'))
+        gen.set_stream('my_param', 42.0)
+        gen.pfields.append('my_param')
+        gen.note_limit = 1
+        gen.generate_notes()
+
+        # my_param should be the last column in the score line
+        fields = gen.notes[0].split()
+        self.assertAlmostEqual(float(fields[-1]), 42.0)
+
+    def test_custom_pfield_absent_from_score_if_not_in_pfields(self):
+        # A stream key that exists in streams but NOT in pfields does not
+        # produce an extra column in the score output.
+        gen = (Line()
+               .with_rhythm(Itemstream(['q'], notetype=notetypes.rhythm))
+               .with_pitches('c4'))
+        default_field_count = len(gen.pfields)
+        gen.set_stream('hidden', 99.0)
+        # deliberately NOT appending 'hidden' to pfields
+        gen.note_limit = 1
+        gen.generate_notes()
+
+        fields = gen.notes[0].split()
+        # +1 for the 'i' prefix on instrument field
+        self.assertEqual(len(fields), default_field_count + 1)
+
+    def test_pfields_append_pattern_used_in_csound_pieces(self):
+        # Real-world pattern: container.pfields += [keys.index, 'orig_rhythm', 'inst_file']
+        # Each appended key must also have a stream, otherwise it emits empty string.
+        gen = (Line()
+               .with_rhythm(Itemstream(['q'], notetype=notetypes.rhythm))
+               .with_pitches('c4'))
+        gen.set_stream(keys.index, 7.0)
+        gen.set_stream('fade_in', 0.001)
+        gen.pfields += [keys.index, 'fade_in']
+        gen.note_limit = 1
+        gen.generate_notes()
+
+        fields = gen.notes[0].split()
+        # Second-to-last: index, last: fade_in
+        self.assertAlmostEqual(float(fields[-2]), 7.0)
+        self.assertAlmostEqual(float(fields[-1]), 0.001)
+
+    def test_generator_dur_limits_child_to_relative_duration(self):
+        # generator_dur sets a relative duration for a child generator.
+        # The child's effective time_limit becomes child.start_time + generator_dur.
+        # At 120bpm, q = 0.5s.  Child starts at 2.0 with generator_dur=1.0,
+        # so time_limit = 3.0.  Notes at 2.0 and 2.5 are within; 3.0 is not.
+        parent = NoteGenerator(
+            streams=OrderedDict([
+                (keys.instrument, Itemstream([1])),
+                (keys.duration, Itemstream([0.5])),
+                (keys.rhythm, Itemstream(['q'], notetype=notetypes.rhythm)),
+            ]),
+            note_limit=1
+        )
+        child = NoteGenerator(
+            streams=OrderedDict([
+                (keys.instrument, Itemstream([1])),
+                (keys.duration, Itemstream([0.5])),
+                (keys.rhythm, Itemstream(['q'], notetype=notetypes.rhythm)),
+            ]),
+            start_time=2.0,
+            note_limit=100   # high enough that only generator_dur stops it
+        )
+        child.generator_dur = 1.0
+
+        parent.add_generator(child)
+        parent.generate_notes()
+
+        child_notes = [n for n in parent.notes if float(n.split()[1]) >= 2.0]
+        child_start_times = sorted([float(n.split()[1]) for n in child_notes])
+
+        # Only notes at 2.0 and 2.5 should appear; 3.0+ is beyond time_limit
+        self.assertEqual(child_start_times, [2.0, 2.5])
+
+    def test_generator_dur_start_time_is_absolute_not_offset_by_parent(self):
+        # When generator_dur > 0, the child's start_time is treated as absolute
+        # and is NOT offset by the parent's start_time.  This is different from
+        # the normal child behavior where start_time is relative to the parent.
+        parent = NoteGenerator(
+            streams=OrderedDict([
+                (keys.instrument, Itemstream([1])),
+                (keys.duration, Itemstream([0.5])),
+                (keys.rhythm, Itemstream(['q'], notetype=notetypes.rhythm)),
+            ]),
+            note_limit=1,
+            start_time=5.0    # parent starts at t=5.0
+        )
+        child = NoteGenerator(
+            streams=OrderedDict([
+                (keys.instrument, Itemstream([1])),
+                (keys.duration, Itemstream([0.5])),
+                (keys.rhythm, Itemstream(['q'], notetype=notetypes.rhythm)),
+            ]),
+            start_time=2.0,   # absolute — NOT relative to parent's 5.0
+            note_limit=1
+        )
+        child.generator_dur = 1.0
+
+        parent.add_generator(child)
+        parent.generate_notes()
+
+        child_start_times = [float(n.split()[1]) for n in parent.notes
+                             if float(n.split()[1]) != 5.0]
+        # Child starts at 2.0 (absolute), NOT 5.0 + 2.0 = 7.0
+        self.assertIn(2.0, child_start_times)
+        self.assertNotIn(7.0, child_start_times)
+
+    def test_generator_dur_vs_time_limit_distinction(self):
+        # time_limit is an absolute clock position; generator_dur is relative
+        # to the child's own start_time.
+        #
+        # A child at start_time=2.0 with generator_dur=1.0 stops at 3.0.
+        # A child at start_time=0.0 with time_limit=3.0 also stops at 3.0.
+        # Both should produce notes at 0.0, 0.5, 1.0, 1.5, 2.0, 2.5 — 6 notes.
+        # (Note at 3.0 is excluded because cur_time becomes 3.5 > time_limit.)
+        def make_parent_with_child(child):
+            parent = NoteGenerator(
                 streams=OrderedDict([
                     (keys.instrument, Itemstream([1])),
                     (keys.duration, Itemstream([0.5])),
                     (keys.rhythm, Itemstream(['q'], notetype=notetypes.rhythm)),
-                    (keys.frequency, Itemstream(
-                        ['c4', 'd4', 'e4', 'f4', 'g4'],
-                        notetype=notetypes.pitch,
-                        streammode=streammodes.heap
-                    )),
                 ]),
-                note_limit=10
+                note_limit=1
             )
-            return g
+            parent.add_generator(child)
+            parent.generate_notes()
+            return parent
 
-        gen_a = make_gen()
-        gen_b = make_gen()
-        gen_a.set_streams_to_seed(42)
-        gen_b.set_streams_to_seed(42)
-        gen_a.generate_notes()
-        gen_b.generate_notes()
+        child_time_limit = NoteGenerator(
+            streams=OrderedDict([
+                (keys.instrument, Itemstream([1])),
+                (keys.duration, Itemstream([0.5])),
+                (keys.rhythm, Itemstream(['q'], notetype=notetypes.rhythm)),
+            ]),
+            note_limit=100
+        )
+        child_time_limit.time_limit = 3.0   # absolute: stop when clock >= 3.0
 
-        self.assertEqual(gen_a.notes, gen_b.notes)
+        child_generator_dur = NoteGenerator(
+            streams=OrderedDict([
+                (keys.instrument, Itemstream([1])),
+                (keys.duration, Itemstream([0.5])),
+                (keys.rhythm, Itemstream(['q'], notetype=notetypes.rhythm)),
+            ]),
+            start_time=2.0,
+            note_limit=100
+        )
+        child_generator_dur.generator_dur = 1.0  # relative: span 1.0s from start_time
 
-    def test_set_streams_to_seed_different_seeds_different_output(self):
-        # Different seeds produce different random draws.
-        def make_gen():
-            return NoteGenerator(
-                streams=OrderedDict([
-                    (keys.instrument, Itemstream([1])),
-                    (keys.duration, Itemstream([0.5])),
-                    (keys.rhythm, Itemstream(['q'], notetype=notetypes.rhythm)),
-                    (keys.frequency, Itemstream(
-                        ['c4', 'd4', 'e4', 'f4', 'g4'],
-                        notetype=notetypes.pitch,
-                        streammode=streammodes.heap
-                    )),
-                ]),
-                note_limit=10
-            )
+        parent_a = make_parent_with_child(child_time_limit)
+        parent_b = make_parent_with_child(child_generator_dur)
 
-        gen_a = make_gen()
-        gen_b = make_gen()
-        gen_a.set_streams_to_seed(1)
-        gen_b.set_streams_to_seed(9999)
-        gen_a.generate_notes()
-        gen_b.generate_notes()
+        a_child_times = sorted([float(n.split()[1]) for n in parent_a.notes
+                                 if float(n.split()[1]) > 0])
+        b_child_times = sorted([float(n.split()[1]) for n in parent_b.notes
+                                 if float(n.split()[1]) >= 2.0])
 
-        self.assertNotEqual(gen_a.notes, gen_b.notes)
-
-    def test_set_streams_to_seed_also_reseeds_context_streams(self):
-        # set_streams_to_seed reseeds Itemstreams stored in context as well,
-        # so post_processes that draw from context streams are also reproducible.
-        def make_gen():
-            def pp(note, context):
-                note.pfields[keys.amplitude] = context['vals'].get_next_value()
-
-            return NoteGenerator(
-                streams=OrderedDict([
-                    (keys.instrument, Itemstream([1])),
-                    (keys.duration, Itemstream([0.5])),
-                    (keys.rhythm, Itemstream(['q'], notetype=notetypes.rhythm)),
-                ]),
-                note_limit=4,
-                post_processes=[pp],
-                init_context={'vals': Itemstream([1.0, 2.0, 3.0, 4.0], streammode=streammodes.heap)}
-            )
-
-        gen_a = make_gen()
-        gen_b = make_gen()
-        gen_a.set_streams_to_seed(77)
-        gen_b.set_streams_to_seed(77)
-        gen_a.generate_notes()
-        gen_b.generate_notes()
-
-        self.assertEqual(gen_a.notes, gen_b.notes)
+        # time_limit child: notes at 0.5, 1.0, 1.5, 2.0, 2.5 (start_time offset by parent's 0)
+        self.assertEqual(a_child_times, [0.5, 1.0, 1.5, 2.0, 2.5])
+        # generator_dur child: notes at 2.0, 2.5
+        self.assertEqual(b_child_times, [2.0, 2.5])
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -659,5 +659,94 @@ class TestGenerators(unittest.TestCase):
         line = Line().with_pitches(stream)
         self.assertEqual(line.streams[keys.frequency].notetype, notetypes.pitch)
 
+    # ------------------------------------------------------------------ #
+    # set_streams_to_seed  (#31)
+    # ------------------------------------------------------------------ #
+
+    def test_set_streams_to_seed_two_generators_same_seed_same_output(self):
+        # Two independent generators with identical config and the same seed
+        # passed to set_streams_to_seed() before generate_notes() produce
+        # identical note lists. This is how it's used in csound-pieces to
+        # create deterministic variations:
+        #   gen1.set_streams_to_seed(int(time.time()))
+        #   gen2.set_streams_to_seed(int(time.time()) + 100)
+        def make_gen():
+            g = NoteGenerator(
+                streams=OrderedDict([
+                    (keys.instrument, Itemstream([1])),
+                    (keys.duration, Itemstream([0.5])),
+                    (keys.rhythm, Itemstream(['q'], notetype=notetypes.rhythm)),
+                    (keys.frequency, Itemstream(
+                        ['c4', 'd4', 'e4', 'f4', 'g4'],
+                        notetype=notetypes.pitch,
+                        streammode=streammodes.heap
+                    )),
+                ]),
+                note_limit=10
+            )
+            return g
+
+        gen_a = make_gen()
+        gen_b = make_gen()
+        gen_a.set_streams_to_seed(42)
+        gen_b.set_streams_to_seed(42)
+        gen_a.generate_notes()
+        gen_b.generate_notes()
+
+        self.assertEqual(gen_a.notes, gen_b.notes)
+
+    def test_set_streams_to_seed_different_seeds_different_output(self):
+        # Different seeds produce different random draws.
+        def make_gen():
+            return NoteGenerator(
+                streams=OrderedDict([
+                    (keys.instrument, Itemstream([1])),
+                    (keys.duration, Itemstream([0.5])),
+                    (keys.rhythm, Itemstream(['q'], notetype=notetypes.rhythm)),
+                    (keys.frequency, Itemstream(
+                        ['c4', 'd4', 'e4', 'f4', 'g4'],
+                        notetype=notetypes.pitch,
+                        streammode=streammodes.heap
+                    )),
+                ]),
+                note_limit=10
+            )
+
+        gen_a = make_gen()
+        gen_b = make_gen()
+        gen_a.set_streams_to_seed(1)
+        gen_b.set_streams_to_seed(9999)
+        gen_a.generate_notes()
+        gen_b.generate_notes()
+
+        self.assertNotEqual(gen_a.notes, gen_b.notes)
+
+    def test_set_streams_to_seed_also_reseeds_context_streams(self):
+        # set_streams_to_seed reseeds Itemstreams stored in context as well,
+        # so post_processes that draw from context streams are also reproducible.
+        def make_gen():
+            def pp(note, context):
+                note.pfields[keys.amplitude] = context['vals'].get_next_value()
+
+            return NoteGenerator(
+                streams=OrderedDict([
+                    (keys.instrument, Itemstream([1])),
+                    (keys.duration, Itemstream([0.5])),
+                    (keys.rhythm, Itemstream(['q'], notetype=notetypes.rhythm)),
+                ]),
+                note_limit=4,
+                post_processes=[pp],
+                init_context={'vals': Itemstream([1.0, 2.0, 3.0, 4.0], streammode=streammodes.heap)}
+            )
+
+        gen_a = make_gen()
+        gen_b = make_gen()
+        gen_a.set_streams_to_seed(77)
+        gen_b.set_streams_to_seed(77)
+        gen_a.generate_notes()
+        gen_b.generate_notes()
+
+        self.assertEqual(gen_a.notes, gen_b.notes)
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_itemstream.py
+++ b/tests/test_itemstream.py
@@ -123,6 +123,106 @@ class TestItemstreams(unittest.TestCase):
 
 
     # ------------------------------------------------------------------ #
+    # Tuple streams: mapping_keys/mapping_lists get_next_value  (#35)
+    # ------------------------------------------------------------------ #
+
+    def test_mapping_stream_get_next_value_returns_correct_dict(self):
+        # get_next_value() on a mapping stream returns a dict whose keys
+        # match mapping_keys and whose values come from the corresponding list.
+        rhythms = ['h', 'q', 'e']
+        indexes = [1.0, 2.0, 3.0]
+        stream = Itemstream(
+            mapping_keys=[keys.rhythm, keys.index],
+            mapping_lists=[rhythms, indexes]
+        )
+        first = stream.get_next_value()
+        self.assertEqual(first[keys.rhythm], 'h')
+        self.assertAlmostEqual(first[keys.index], 1.0)
+
+    def test_mapping_stream_values_advance_in_sync(self):
+        # Each call to get_next_value() advances both lists together —
+        # the nth call always returns the nth pair, never mixing pairs.
+        rhythms = ['h', 'q', 'e']
+        indexes = [1.0, 2.0, 3.0]
+        stream = Itemstream(
+            mapping_keys=[keys.rhythm, keys.index],
+            mapping_lists=[rhythms, indexes]
+        )
+        results = [stream.get_next_value() for _ in range(3)]
+        self.assertEqual(results[0][keys.rhythm], 'h')
+        self.assertAlmostEqual(results[0][keys.index], 1.0)
+        self.assertEqual(results[1][keys.rhythm], 'q')
+        self.assertAlmostEqual(results[1][keys.index], 2.0)
+        self.assertEqual(results[2][keys.rhythm], 'e')
+        self.assertAlmostEqual(results[2][keys.index], 3.0)
+
+    def test_mapping_stream_wraps_in_sequence_mode(self):
+        # After the last pair, the stream wraps back to the first pair.
+        rhythms = ['h', 'q']
+        indexes = [1.0, 2.0]
+        stream = Itemstream(
+            mapping_keys=[keys.rhythm, keys.index],
+            mapping_lists=[rhythms, indexes],
+            streammode=streammodes.sequence
+        )
+        # Exhaust + one more
+        stream.get_next_value()
+        stream.get_next_value()
+        wrapped = stream.get_next_value()
+        self.assertEqual(wrapped[keys.rhythm], 'h')
+        self.assertAlmostEqual(wrapped[keys.index], 1.0)
+
+    def test_mapping_stream_shorter_list_wraps_independently(self):
+        # When lists have different lengths, the shorter one wraps to fill
+        # the longer one's length (Itemstream constructor pads with wrap).
+        rhythms = ['h', 'q', 'e', 'w']   # length 4
+        indexes = [1.0, 2.0]              # length 2 — wraps: 1.0, 2.0, 1.0, 2.0
+        stream = Itemstream(
+            mapping_keys=[keys.rhythm, keys.index],
+            mapping_lists=[rhythms, indexes]
+        )
+        results = [stream.get_next_value() for _ in range(4)]
+        self.assertEqual([r[keys.rhythm] for r in results], ['h', 'q', 'e', 'w'])
+        self.assertEqual([r[keys.index] for r in results], [1.0, 2.0, 1.0, 2.0])
+
+    def test_mapping_stream_in_post_process_sets_pfields(self):
+        # The dominant real-world pattern: a tuple stream lives in context
+        # and a post_process reads from it to set note.rhythm and a custom pfield.
+        # This is the core of every index-based granular synthesis piece.
+        rhythms = ['h', 'q', 'e']
+        indexes = [0.5, 1.5, 2.5]
+        tempo = 120
+
+        def parse_tuple(note, context):
+            item = context['tuplestream'].get_next_value()
+            note.rhythm = utils.rhythm_to_duration(item[keys.rhythm], tempo)
+            note.pfields[keys.index] = item[keys.index]
+
+        gen = NoteGenerator(
+            streams=OrderedDict([
+                (keys.instrument, Itemstream([1])),
+                (keys.duration, Itemstream([0.5])),
+            ]),
+            pfields=[keys.instrument, keys.start_time, keys.duration, keys.index],
+            note_limit=3,
+            post_processes=[parse_tuple],
+            init_context={
+                'tuplestream': Itemstream(
+                    mapping_keys=[keys.rhythm, keys.index],
+                    mapping_lists=[rhythms, indexes],
+                    tempo=tempo
+                )
+            }
+        )
+        gen.generate_notes()
+
+        # Each note should have the index from the corresponding tuple
+        index_values = [float(note.split()[3]) for note in gen.notes]
+        self.assertAlmostEqual(index_values[0], 0.5)
+        self.assertAlmostEqual(index_values[1], 1.5)
+        self.assertAlmostEqual(index_values[2], 2.5)
+
+    # ------------------------------------------------------------------ #
     # streammode=random  (#31)
     # ------------------------------------------------------------------ #
 

--- a/tests/test_itemstream.py
+++ b/tests/test_itemstream.py
@@ -1,5 +1,6 @@
 import unittest
 from thuja.notegenerator import *
+from thuja.itemstream import streammodes, notetypes
 import numpy as np
 
 
@@ -119,6 +120,82 @@ class TestItemstreams(unittest.TestCase):
 
         score = g.generate_score_string()
         self.assertTrue(len(score.split('\n')) == 248)
+
+
+    # ------------------------------------------------------------------ #
+    # streammode=random  (#31)
+    # ------------------------------------------------------------------ #
+
+    def test_random_streammode_values_come_from_defined_set(self):
+        # random mode returns values drawn from the stream's value list.
+        allowed = {'a', 'b', 'c', 'd'}
+        stream = Itemstream(list(allowed), streammode=streammodes.random)
+        for _ in range(40):
+            self.assertIn(stream.get_next_value(), allowed)
+
+    def test_random_streammode_allows_value_repetition(self):
+        # Unlike heap, random mode can return the same value on consecutive calls.
+        # With a 2-item list and 20 draws, repetition is statistically certain.
+        stream = Itemstream(['x', 'y'], streammode=streammodes.random, seed=42)
+        draws = [stream.get_next_value() for _ in range(20)]
+        # If every adjacent pair were different, the list would perfectly alternate.
+        # With random mode, at least one repeat must appear.
+        has_repeat = any(draws[i] == draws[i + 1] for i in range(len(draws) - 1))
+        self.assertTrue(has_repeat, "random mode should allow consecutive repeats")
+
+    # ------------------------------------------------------------------ #
+    # heap exhaustion and refill  (#31)
+    # ------------------------------------------------------------------ #
+
+    def test_heap_streammode_no_repeat_within_one_cycle(self):
+        # heap mode exhausts all values before repeating any.
+        # Over exactly N draws from an N-item stream, each value appears exactly once.
+        values = ['a', 'b', 'c', 'd', 'e']
+        stream = Itemstream(values, streammode=streammodes.heap, seed=42)
+        draws = [stream.get_next_value() for _ in range(len(values))]
+        self.assertEqual(sorted(draws), sorted(values))
+
+    def test_heap_streammode_refills_after_exhaustion(self):
+        # After all N values are drawn, the heap refills and a second cycle begins.
+        # Both cycles contain all N values in (potentially different) random order.
+        values = ['a', 'b', 'c']
+        stream = Itemstream(values, streammode=streammodes.heap, seed=42)
+        first_cycle = [stream.get_next_value() for _ in range(len(values))]
+        second_cycle = [stream.get_next_value() for _ in range(len(values))]
+        self.assertEqual(sorted(first_cycle), sorted(values))
+        self.assertEqual(sorted(second_cycle), sorted(values))
+
+    # ------------------------------------------------------------------ #
+    # seed constructor param  (#31)
+    # ------------------------------------------------------------------ #
+
+    def test_seed_param_produces_same_heap_sequence(self):
+        # Two Itemstreams with the same seed and same values produce identical sequences.
+        values = ['a', 'b', 'c', 'd', 'e', 'f']
+        s1 = Itemstream(values, streammode=streammodes.heap, seed=42)
+        s2 = Itemstream(values, streammode=streammodes.heap, seed=42)
+        draws_1 = [s1.get_next_value() for _ in range(len(values) * 3)]
+        draws_2 = [s2.get_next_value() for _ in range(len(values) * 3)]
+        self.assertEqual(draws_1, draws_2)
+
+    def test_seed_param_produces_same_random_sequence(self):
+        # Same guarantee applies to random mode: same seed → same sequence.
+        values = ['a', 'b', 'c', 'd']
+        s1 = Itemstream(values, streammode=streammodes.random, seed=99)
+        s2 = Itemstream(values, streammode=streammodes.random, seed=99)
+        draws_1 = [s1.get_next_value() for _ in range(20)]
+        draws_2 = [s2.get_next_value() for _ in range(20)]
+        self.assertEqual(draws_1, draws_2)
+
+    def test_different_seeds_produce_different_sequences(self):
+        # Two streams with different seeds should (with high probability) produce
+        # different orderings over 3 heap cycles.
+        values = ['a', 'b', 'c', 'd', 'e', 'f']
+        s1 = Itemstream(values, streammode=streammodes.heap, seed=1)
+        s2 = Itemstream(values, streammode=streammodes.heap, seed=9999)
+        draws_1 = [s1.get_next_value() for _ in range(len(values) * 3)]
+        draws_2 = [s2.get_next_value() for _ in range(len(values) * 3)]
+        self.assertNotEqual(draws_1, draws_2)
 
 
 if __name__ == '__main__':

--- a/thuja/itemstream.py
+++ b/thuja/itemstream.py
@@ -118,6 +118,14 @@ class Itemstream:
                     item[key] = mapping_lists[keydx][i % len(mapping_lists[keydx])]
                 self.values.append(item)
 
+        # For random-order modes, start at a random index so the first draw is not
+        # always values[0]. For heap mode, mark that index as used so it won't be
+        # drawn again until the heap refills.
+        if self.values and self.streammode in (streammodes.heap, streammodes.random):
+            self.index = self.rand.randrange(0, len(self.values))
+            if self.streammode == streammodes.heap:
+                self.heapdict.add(self.index)
+
     # Random seeds can be set after copying a generator, so that random processes (streammodes == heap or random,
     #   for example) produce fresh values. Likewise, reusing a seed on a generator ensures repeatable results
     #   from the generator's random- or heap-mode streams.


### PR DESCRIPTION
## Bug fixed

`heap` and `random` Itemstreams always returned `values[0]` as the first draw. `self.index` was initialized to `0` and the random selection logic ran **after** returning the current value, not before. So regardless of the seed, the first call to `get_next_value()` on a fresh heap/random stream always returned the first element. For heap mode this also meant one value could appear twice (and another not at all) within a single N-draw cycle.

**Fix:** at the end of `Itemstream.__init__`, for `heap` and `random` streammodes, initialize `self.index` to a random position. For heap mode, also add that index to `heapdict` so it is treated as already drawn and won't repeat until the heap refills.

## New tests

**test_itemstream.py:**
- `streammode=random` values come from defined set
- `streammode=random` allows consecutive repeats (unlike heap)
- Heap: exactly N distinct values in exactly N draws — one clean cycle
- Heap: second cycle after exhaustion also covers all N values
- Same seed → same sequence (heap and random modes)
- Different seeds → different sequences

**test_generator.py:**
- `set_streams_to_seed()`: two generators with same seed produce identical note output
- `set_streams_to_seed()`: different seeds produce different output
- `set_streams_to_seed()`: context Itemstreams are also reseeded

## Test plan
- [ ] All 63 tests pass: `cd tests && python -m unittest discover`