### PR TITLE
Tests: lambda streams on non-duration fields (#32)

### DIFF
--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -659,5 +659,90 @@ class TestGenerators(unittest.TestCase):
         line = Line().with_pitches(stream)
         self.assertEqual(line.streams[keys.frequency].notetype, notetypes.pitch)
 
+    # ------------------------------------------------------------------ #
+    # Lambda streams on non-duration fields  (#32)
+    # ------------------------------------------------------------------ #
+    # Line default pfield order in the score string (split by whitespace):
+    #   [0] = 'i' + instrument
+    #   [1] = start_time
+    #   [2] = duration
+    #   [3] = amplitude
+    #   [4] = frequency
+    #   [5] = pan
+    #   [6] = distance
+    #   [7] = percent
+
+    def test_lambda_on_pan_produces_constant_return_value(self):
+        # A lambda assigned to pan is called once per note.
+        # The return value appears at position [5] in the score line.
+        gen = (Line()
+               .with_rhythm(Itemstream(['q'], notetype=notetypes.rhythm))
+               .with_pitches('c4')
+               .with_pan(lambda note: 72.0))
+        gen.note_limit = 4
+        gen.generate_notes()
+
+        for note in gen.notes:
+            self.assertAlmostEqual(float(note.split()[5]), 72.0)
+
+    def test_lambda_on_amplitude_produces_constant_return_value(self):
+        # A lambda assigned to amplitude is called once per note.
+        # The return value appears at position [3] in the score line.
+        gen = (Line()
+               .with_rhythm(Itemstream(['q'], notetype=notetypes.rhythm))
+               .with_pitches('c4')
+               .with_amps(lambda note: 0.25))
+        gen.note_limit = 4
+        gen.generate_notes()
+
+        for note in gen.notes:
+            self.assertAlmostEqual(float(note.split()[3]), 0.25)
+
+    def test_lambda_on_percent_produces_constant_return_value(self):
+        # A lambda assigned to percent is called once per note.
+        # The return value appears at position [7] in the score line.
+        gen = (Line()
+               .with_rhythm(Itemstream(['q'], notetype=notetypes.rhythm))
+               .with_pitches('c4')
+               .with_percent(lambda note: 0.99))
+        gen.note_limit = 4
+        gen.generate_notes()
+
+        for note in gen.notes:
+            self.assertAlmostEqual(float(note.split()[7]), 0.99)
+
+    def test_lambda_on_pan_can_read_note_rhythm(self):
+        # Lambdas receive the note object after rhythm is set, so they can
+        # reference note.rhythm to compute a value. This is the pattern used
+        # in csound-pieces for tempo-aware pfield values.
+        # At 120bpm, q = 0.5s.  The lambda returns rhythm * 100 = 50.0.
+        gen = (Line()
+               .with_rhythm(Itemstream(['q'], notetype=notetypes.rhythm))
+               .with_pitches('c4')
+               .with_pan(lambda note: note.rhythm * 100))
+        gen.note_limit = 2
+        gen.generate_notes()
+
+        for note in gen.notes:
+            self.assertAlmostEqual(float(note.split()[5]), 50.0)
+
+    def test_lambda_produces_different_values_per_note(self):
+        # Lambdas are called fresh for each note, so they can vary per note.
+        counter = {'n': 0}
+
+        def incrementing_pan(note):
+            counter['n'] += 10
+            return float(counter['n'])
+
+        gen = (Line()
+               .with_rhythm(Itemstream(['q'], notetype=notetypes.rhythm))
+               .with_pitches('c4')
+               .with_pan(incrementing_pan))
+        gen.note_limit = 3
+        gen.generate_notes()
+
+        pan_values = [float(note.split()[5]) for note in gen.notes]
+        self.assertEqual(pan_values, [10.0, 20.0, 30.0])
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

Adds tests for lambdas used as stream values on pan, amplitude, and percent — the most common lambda pattern in csound-pieces (42 files) that was previously untested.

## New tests (test_generator.py)

- `test_lambda_on_pan_produces_constant_return_value` — lambda on pan, value at score position [5]
- `test_lambda_on_amplitude_produces_constant_return_value` — lambda on amplitude, position [3]
- `test_lambda_on_percent_produces_constant_return_value` — lambda on percent, position [7]
- `test_lambda_on_pan_can_read_note_rhythm` — lambda receives note with rhythm set; `note.rhythm * 100` resolves correctly
- `test_lambda_produces_different_values_per_note` — lambda called fresh per note, accumulates state via closure

## Test plan
- [ ] All 58 tests pass: `cd tests && python -m unittest discover`