### PR TITLE
Tests: Line fluent API — with_instr, with_index, path notetype, pfields appending (#34)

### DIFF
--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -659,5 +659,108 @@ class TestGenerators(unittest.TestCase):
         line = Line().with_pitches(stream)
         self.assertEqual(line.streams[keys.frequency].notetype, notetypes.pitch)
 
+    # ------------------------------------------------------------------ #
+    # Line fluent API: with_instr, with_index, path notetype, pfields  (#34)
+    # ------------------------------------------------------------------ #
+    # Line default pfield order in the score string (split by whitespace):
+    #   [0] = 'i' + instrument    instrument is embedded: 'i1', 'i4', etc.
+    #   [1] = start_time
+    #   [2] = duration
+    #   [3] = amplitude
+    #   [4] = frequency
+    #   [5] = pan  ...
+
+    def test_with_instr_sets_instrument_number_in_score(self):
+        # with_instr(n) sets p1 — the Csound instrument number.
+        # In the score string, instrument is embedded in split()[0] as 'i<n>'.
+        gen = (Line()
+               .with_rhythm(Itemstream(['q'], notetype=notetypes.rhythm))
+               .with_pitches('c4')
+               .with_instr(7))
+        gen.note_limit = 1
+        gen.generate_notes()
+
+        instr = int(gen.notes[0].split()[0][1:])   # strip leading 'i'
+        self.assertEqual(instr, 7)
+
+    def test_with_index_value_appears_in_score(self):
+        # with_index(n) adds an index stream, but index must also be in pfields
+        # to appear in the score — this mirrors the real usage pattern where
+        # setup_index_params or manual pfields.append() is required.
+        gen = (Line()
+               .with_rhythm(Itemstream(['q'], notetype=notetypes.rhythm))
+               .with_pitches('c4')
+               .with_index(3.5))
+        gen.pfields.append(keys.index)
+        gen.note_limit = 1
+        gen.generate_notes()
+
+        fields = gen.notes[0].split()
+        index_val = float(fields[len(fields) - 1])   # last column
+        self.assertAlmostEqual(index_val, 3.5)
+
+    def test_path_notetype_returns_quoted_string_unchanged(self):
+        # notetypes.path wraps the string in double-quotes and passes it through
+        # without any pitch or rhythm conversion.
+        stream = Itemstream(['/samples/kick.wav'], notetype=notetypes.path)
+        val = stream.get_next_value()
+        self.assertEqual(val, '"/samples/kick.wav"')
+
+    def test_path_notetype_does_not_convert_to_frequency(self):
+        # A path string would raise an error or produce garbage if treated as pitch.
+        # Confirm notetypes.path leaves the value intact as a string.
+        stream = Itemstream(['/samples/snare.wav'], notetype=notetypes.path)
+        val = stream.get_next_value()
+        self.assertIsInstance(val, str)
+        self.assertIn('/samples/snare.wav', val)
+
+    def test_custom_pfield_appended_to_pfields_appears_in_score(self):
+        # A custom stream added via set_stream() only appears in the score
+        # when its key is also appended to generator.pfields.
+        gen = (Line()
+               .with_rhythm(Itemstream(['q'], notetype=notetypes.rhythm))
+               .with_pitches('c4'))
+        gen.set_stream('my_param', 42.0)
+        gen.pfields.append('my_param')
+        gen.note_limit = 1
+        gen.generate_notes()
+
+        # my_param should be the last column in the score line
+        fields = gen.notes[0].split()
+        self.assertAlmostEqual(float(fields[-1]), 42.0)
+
+    def test_custom_pfield_absent_from_score_if_not_in_pfields(self):
+        # A stream key that exists in streams but NOT in pfields does not
+        # produce an extra column in the score output.
+        gen = (Line()
+               .with_rhythm(Itemstream(['q'], notetype=notetypes.rhythm))
+               .with_pitches('c4'))
+        default_field_count = len(gen.pfields)
+        gen.set_stream('hidden', 99.0)
+        # deliberately NOT appending 'hidden' to pfields
+        gen.note_limit = 1
+        gen.generate_notes()
+
+        fields = gen.notes[0].split()
+        # +1 for the 'i' prefix on instrument field
+        self.assertEqual(len(fields), default_field_count + 1)
+
+    def test_pfields_append_pattern_used_in_csound_pieces(self):
+        # Real-world pattern: container.pfields += [keys.index, 'orig_rhythm', 'inst_file']
+        # Each appended key must also have a stream, otherwise it emits empty string.
+        gen = (Line()
+               .with_rhythm(Itemstream(['q'], notetype=notetypes.rhythm))
+               .with_pitches('c4'))
+        gen.set_stream(keys.index, 7.0)
+        gen.set_stream('fade_in', 0.001)
+        gen.pfields += [keys.index, 'fade_in']
+        gen.note_limit = 1
+        gen.generate_notes()
+
+        fields = gen.notes[0].split()
+        # Second-to-last: index, last: fade_in
+        self.assertAlmostEqual(float(fields[-2]), 7.0)
+        self.assertAlmostEqual(float(fields[-1]), 0.001)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

Tests for Line API surface used in 12–23 files in csound-pieces with no existing assertions.

## New tests (test_generator.py)

- `test_with_instr_sets_instrument_number_in_score` — p1 = 7, score line starts with 'i7'
- `test_with_index_value_appears_in_score` — index added to pfields, appears as last column
- `test_path_notetype_returns_quoted_string_unchanged` — '/samples/kick.wav' → '"/samples/kick.wav"'
- `test_path_notetype_does_not_convert_to_frequency` — value is a string, not a number
- `test_custom_pfield_appended_to_pfields_appears_in_score` — set_stream + pfields.append pattern
- `test_custom_pfield_absent_from_score_if_not_in_pfields` — stream exists but column absent
- `test_pfields_append_pattern_used_in_csound_pieces` — `pfields += [keys.index, 'fade_in']`

## Test plan
- [ ] All 60 tests pass: `cd tests && python -m unittest discover`